### PR TITLE
[Feat] 상세> 유저 정보 API

### DIFF
--- a/src/main/java/com/sopt/carrot_server/app/application/UserService.java
+++ b/src/main/java/com/sopt/carrot_server/app/application/UserService.java
@@ -1,0 +1,34 @@
+package com.sopt.carrot_server.app.application;
+import com.sopt.carrot_server.app.domain.Address;
+import com.sopt.carrot_server.app.domain.User;
+import com.sopt.carrot_server.app.domain.repository.AddressRepository;
+import com.sopt.carrot_server.app.domain.repository.UserRepository;
+import com.sopt.carrot_server.app.dto.response.UserResponse;
+import com.sopt.carrot_server.app.mapper.UserMapper;
+import com.sopt.carrot_server.global.common.code.FailureCode;
+import com.sopt.carrot_server.global.common.exception.UserException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final AddressRepository addressRepository;
+
+    public UserService(UserRepository userRepository,AddressRepository addressRepository){
+        this.userRepository = userRepository;
+        this.addressRepository = addressRepository;
+    }
+
+    public UserResponse getUserById(Long userId){
+
+        //1. 유저 조회
+        User user = userRepository.findById(userId).orElseThrow(()-> new UserException(FailureCode.INVALID_VALUE));
+
+        //2. 주소 조회
+        Address address = addressRepository.findById(user.getAddressId()).orElseThrow(()-> new UserException(FailureCode.MISSING_PARAMETER));
+
+        return UserMapper.toResponse(user,address);
+
+    }
+}

--- a/src/main/java/com/sopt/carrot_server/app/application/UserService.java
+++ b/src/main/java/com/sopt/carrot_server/app/application/UserService.java
@@ -1,12 +1,16 @@
 package com.sopt.carrot_server.app.application;
+
 import com.sopt.carrot_server.app.domain.Address;
 import com.sopt.carrot_server.app.domain.User;
 import com.sopt.carrot_server.app.domain.repository.AddressRepository;
 import com.sopt.carrot_server.app.domain.repository.UserRepository;
 import com.sopt.carrot_server.app.dto.response.UserResponse;
 import com.sopt.carrot_server.app.mapper.UserMapper;
+
 import com.sopt.carrot_server.global.common.code.FailureCode;
+import com.sopt.carrot_server.global.common.exception.AddressException;
 import com.sopt.carrot_server.global.common.exception.UserException;
+
 import org.springframework.stereotype.Service;
 
 @Service
@@ -23,10 +27,10 @@ public class UserService {
     public UserResponse getUserById(Long userId){
 
         //1. 유저 조회
-        User user = userRepository.findById(userId).orElseThrow(()-> new UserException(FailureCode.INVALID_VALUE));
+        User user = userRepository.findById(userId).orElseThrow(()-> new UserException(FailureCode.USER_NOT_FOUND));
 
         //2. 주소 조회
-        Address address = addressRepository.findById(user.getAddressId()).orElseThrow(()-> new UserException(FailureCode.MISSING_PARAMETER));
+        Address address = addressRepository.findById(user.getAddressId()).orElseThrow(()-> new AddressException(FailureCode.INVALID_VALUE));
 
         return UserMapper.toResponse(user,address);
 

--- a/src/main/java/com/sopt/carrot_server/app/domain/repository/AddressRepository.java
+++ b/src/main/java/com/sopt/carrot_server/app/domain/repository/AddressRepository.java
@@ -1,0 +1,7 @@
+package com.sopt.carrot_server.app.domain.repository;
+
+import com.sopt.carrot_server.app.domain.Address;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AddressRepository extends JpaRepository<Address,Long> {
+}

--- a/src/main/java/com/sopt/carrot_server/app/domain/repository/UserRepository.java
+++ b/src/main/java/com/sopt/carrot_server/app/domain/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.sopt.carrot_server.app.domain.repository;
+
+import com.sopt.carrot_server.app.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User,Long> {
+}

--- a/src/main/java/com/sopt/carrot_server/app/dto/response/UserResponse.java
+++ b/src/main/java/com/sopt/carrot_server/app/dto/response/UserResponse.java
@@ -1,13 +1,13 @@
 package com.sopt.carrot_server.app.dto.response;
+
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
-
 public class UserResponse {
     private Long userId;
     private String nickname;
     private String profileImage;
-    private  String address;
+    private String address;
 }

--- a/src/main/java/com/sopt/carrot_server/app/dto/response/UserResponse.java
+++ b/src/main/java/com/sopt/carrot_server/app/dto/response/UserResponse.java
@@ -1,0 +1,13 @@
+package com.sopt.carrot_server.app.dto.response;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+
+public class UserResponse {
+    private Long userId;
+    private String nickname;
+    private String profileImage;
+    private  String address;
+}

--- a/src/main/java/com/sopt/carrot_server/app/mapper/UserMapper.java
+++ b/src/main/java/com/sopt/carrot_server/app/mapper/UserMapper.java
@@ -1,0 +1,17 @@
+package com.sopt.carrot_server.app.mapper;
+
+
+import com.sopt.carrot_server.app.domain.Address;
+import com.sopt.carrot_server.app.domain.User;
+import com.sopt.carrot_server.app.dto.response.UserResponse;
+
+public class UserMapper {
+    public static UserResponse toResponse(User user, Address address){
+        return UserResponse.builder()
+                .userId(user.getId())
+                .nickname(user.getNickname())
+                .profileImage(user.getProfileImage())
+                .address(address.getDistrict() + " " + address.getDong())
+                .build();
+    }
+}

--- a/src/main/java/com/sopt/carrot_server/app/presentation/UserController.java
+++ b/src/main/java/com/sopt/carrot_server/app/presentation/UserController.java
@@ -1,0 +1,29 @@
+package com.sopt.carrot_server.app.presentation;
+
+
+import com.sopt.carrot_server.app.application.UserService;
+import com.sopt.carrot_server.app.dto.response.UserResponse;
+import com.sopt.carrot_server.global.common.code.SuccessCode;
+import com.sopt.carrot_server.global.common.dto.SuccessResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/users")
+public class UserController {
+
+    private final UserService userService;
+
+    public UserController(UserService userService){
+        this.userService = userService;
+    }
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<SuccessResponse<UserResponse>>getUserById(@PathVariable Long userId){
+        UserResponse userResponse = userService.getUserById(userId);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_GET_DIARY_DETAIL,userResponse));
+    }
+}

--- a/src/main/java/com/sopt/carrot_server/app/presentation/UserController.java
+++ b/src/main/java/com/sopt/carrot_server/app/presentation/UserController.java
@@ -1,28 +1,26 @@
 package com.sopt.carrot_server.app.presentation;
 
-
 import com.sopt.carrot_server.app.application.UserService;
 import com.sopt.carrot_server.app.dto.response.UserResponse;
 import com.sopt.carrot_server.global.common.code.SuccessCode;
 import com.sopt.carrot_server.global.common.dto.SuccessResponse;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import lombok.RequiredArgsConstructor;
+
 @RestController
 @RequestMapping("/api/users")
+@RequiredArgsConstructor
 public class UserController {
-
     private final UserService userService;
 
-    public UserController(UserService userService){
-        this.userService = userService;
-    }
-
     @GetMapping("/{userId}")
-    public ResponseEntity<SuccessResponse<UserResponse>>getUserById(@PathVariable Long userId){
+    public ResponseEntity<SuccessResponse<UserResponse>> getUserById(@PathVariable Long userId){
         UserResponse userResponse = userService.getUserById(userId);
         return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_GET_DIARY_DETAIL,userResponse));
     }

--- a/src/main/java/com/sopt/carrot_server/global/common/code/FailureCode.java
+++ b/src/main/java/com/sopt/carrot_server/global/common/code/FailureCode.java
@@ -13,6 +13,8 @@ public enum FailureCode {
 
 
     // User
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND,"해당 유저를 찾을 수 없습니다."),
+
 
     // Product
 

--- a/src/main/java/com/sopt/carrot_server/global/common/exception/AddressException.java
+++ b/src/main/java/com/sopt/carrot_server/global/common/exception/AddressException.java
@@ -1,0 +1,17 @@
+package com.sopt.carrot_server.global.common.exception;
+
+import com.sopt.carrot_server.global.common.code.FailureCode;
+
+public class AddressException extends ApiException {
+    private final FailureCode failureCode;
+
+    public FailureCode getFailureCode() {
+    return failureCode;
+  }
+
+    public AddressException(FailureCode failureCode) {
+      super(failureCode, "[UserException]");
+      this.failureCode = failureCode;
+    }
+}
+


### PR DESCRIPTION
# 💥 Work Description
- 상세조회 페이지에서 유저 정보 받아오는 API 구현 했습니다
- Mapper 클래스로 엔티티를 DTO로 변환했습니다.
- 안드로이드 클라이언트분들이 요청하신 대로, 이중래핑 구조를 적용하지 않았습니다

# ⚙️ ISSUE
- #8

# 💡 변경사항
- 저번에 놓쳤던 Repository패키치 생성했습니다!


# 🌱 PR Point
mapper클래스와 비즈니스 로직에서 더 고려해야할 부분이 있을까요..?

# 🔗 Reference
